### PR TITLE
Update version of linux images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,16 @@ jobs:
   test_linux:
     strategy:
       matrix:
-        image: ["latest-debian-bullseye", "latest-ubuntu-2004", "latest-ubuntu-2204"]
+        image: [
+          "test_debian:bullseye",
+          "test_debian:bookworm",
+          "test_ubuntu:2004",
+          "test_ubuntu:2204",
+          "test_ubuntu:2404"
+          ]
     runs-on: ubuntu-latest
     container:
-        image: koudis/cmakelib-build-linux:${{ matrix.image }}
+        image: ghcr.io/cmakelib/${{ matrix.image }}
     steps:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
@@ -37,10 +43,16 @@ jobs:
   test_linux_script:
     strategy:
       matrix:
-        image: ["latest-debian-bullseye", "latest-ubuntu-2004", "latest-ubuntu-2204"]
+        image: [
+          "test_debian:bullseye",
+          "test_debian:bookworm",
+          "test_ubuntu:2004",
+          "test_ubuntu:2204",
+          "test_ubuntu:2404"
+          ]
     runs-on: ubuntu-latest
     container:
-        image: koudis/cmakelib-build-linux:${{ matrix.image }}
+        image: ghcr.io/cmakelib/${{ matrix.image }}
     steps:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2

--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ then just clean up all intermediate files by
 
     git clean -xfd
 
+## CI/CD test runners
+
+Tests are run by github CI/CD for each PR.
+
+Docker images are stored as cmake [github packages].
+
+Dockerfiles can be found at [docker-build-images] repository.
+
+
 ## Coding style
 
 In library we use Uppercase for all CMake keywords.
@@ -216,11 +225,13 @@ Project is licensed under [BSD-3-Clause License](LICENSE)
 [CMLIB_ARCHIVE]:         ./system_modules/CMLIB_ARCHIVE.cmake
 [CMLIB_DEPENDENCY]:      ./system_modules/CMLIB_DEPENDENCY.cmake
 [CMLIB_COMPONENT]:       ./system_modules/CMLIB_COMPONENT.cmake
-[CMLIB_STORAGE]:         https://github.com/cmakelib/cmakelib-component-storage
-[CMDEF]:                 https://github.com/cmakelib/cmakelib-component-basedef
+[CMLIB_STORAGE]:         ../cmakelib-component-storage
+[CMDEF]:                 ../cmakelib-component-basedef
 [System modules]:        ./system_modules/
 [system modules]:        ./system_modules/
 [example]:               ./example/
 [example/DEPENDENCY]:    ./example/DEPENDENCY
 [buildbadge_github]:     https://github.com/cmakelib/cmakelib/workflows/Tests/badge.svg
 [example/DEPENDENCY/boost_example]: ./example/DEPENDENCY/boost_example/
+[docker-build-images]: ../docker-build-images
+[github packages]: https://github.com/orgs/cmakelib/packages


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new section on "CI/CD test runners" in the README, detailing test execution via GitHub CI/CD.
	- Updated references for `CMLIB_STORAGE` and `CMDEF` to use relative paths.
	- Introduced a new reference to the `docker-build-images` repository for better resource linkage.
	- Made minor formatting adjustments and clarifications throughout the document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->