### PR TITLE
Use Github packages to host images

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,10 +13,12 @@ jobs:
   test_linux:
     strategy:
       matrix:
-        image: ["latest-debian-bullseye", "latest-ubuntu-2004", "latest-ubuntu-2204"]
+        image: ["test_debian:bullseye", "test_debian:bookworm", 
+          "test_ubuntu:2004", "test_ubuntu:2204", "test_ubuntu:2404",
+          "test_fedora:41"]
     runs-on: ubuntu-latest
     container:
-        image: koudis/cmakelib-build-linux:${{ matrix.image }}
+        image: ghcr.io/cmakelib/${{ matrix.image }}
     steps:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2
@@ -37,10 +39,12 @@ jobs:
   test_linux_script:
     strategy:
       matrix:
-        image: ["latest-debian-bullseye", "latest-ubuntu-2004", "latest-ubuntu-2204"]
+        image: ["test_debian:bullseye", "test_debian:bookworm", 
+          "test_ubuntu:2004", "test_ubuntu:2204", "test_ubuntu:2404",
+          "test_fedora:41"]
     runs-on: ubuntu-latest
     container:
-        image: koudis/cmakelib-build-linux:${{ matrix.image }}
+        image: ghcr.io/cmakelib/${{ matrix.image }}
     steps:
       - name: Install SSH key
         uses: shimataro/ssh-key-action@v2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow testing configuration
	- Replaced Linux testing images with new set of distributions
	- Migrated container image source from Docker Hub to GitHub Container Registry

<!-- end of auto-generated comment: release notes by coderabbit.ai -->